### PR TITLE
Modifying ResourceManifest so that "AngularJS" is the dependency of all partial libraries

### DIFF
--- a/ResourceManifest.cs
+++ b/ResourceManifest.cs
@@ -22,38 +22,47 @@ namespace Orchard.AngularJS
             // partial libraries
             manifest.DefineScript("AngularJS_Animate")
                 .SetUrl("angular-animate.min.js", "angular-animate.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Cookies")
                 .SetUrl("angular-cookies.min.js", "angular-cookies.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Loader")
                 .SetUrl("angular-loader.min.js", "angular-loader.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Mocks")
                 .SetUrl("angular-mocks.js", "angular-mocks.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Resource")
                 .SetUrl("angular-resource.min.js", "angular-resource.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Route")
                 .SetUrl("angular-route.min.js", "angular-route.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Sanitize")
                 .SetUrl("angular-sanitize.min.js", "angular-sanitize.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Scenario")
                 .SetUrl("angular-scenario.js", "angular-scenario.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
             manifest.DefineScript("AngularJS_Touch")
                 .SetUrl("angular-touch.min.js", "angular-touch.js")
+                .SetDependencies("AngularJS")
                 .SetVersion(StableVersion);
 
         }


### PR DESCRIPTION
This is useful when using the partial libraries, because you don't have to include e.g. "AngularJS_Animate" plus "AngularJS" (using Script.Require), only "AngularJS_Animate", as it will automatically load "AngularJS" too, since it's now a dependency.
